### PR TITLE
Adds new extension to store BMC passwords in GCD

### DIFF
--- a/bmc-store-password/Dockerfile
+++ b/bmc-store-password/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.14-alpine3.12
+ADD . /go/src/github.com/m-lab/epoxy-extensions/bmc-store-password
+RUN go get -v github.com/m-lab/epoxy-extensions/bmc-store-password
+ENTRYPOINT ["/go/bin/bmc-store-password"]

--- a/bmc-store-password/Dockerfile
+++ b/bmc-store-password/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine3.12
+FROM golang:1.15-alpine3.12
 ADD . /go/src/github.com/m-lab/epoxy-extensions/bmc-store-password
 RUN apk add --no-cache git
 RUN go get -v github.com/m-lab/epoxy-extensions/bmc-store-password

--- a/bmc-store-password/Dockerfile
+++ b/bmc-store-password/Dockerfile
@@ -1,10 +1,5 @@
-FROM golang:1.14-alpine3.12 as extension-build
-RUN apk add --no-cache git
+FROM golang:1.14-alpine3.12
 ADD . /go/src/github.com/m-lab/epoxy-extensions/bmc-store-password
-RUN cd /go/src/github.com/m-lab/epoxy-extensions/bmc-store-password && ./build.sh
-
-# Now copy the built image into the minimal base image
-FROM alpine:3.12
-COPY --from=ext-build /go/bin/bmc-store-password /
-WORKDIR /
-ENTRYPOINT ["/bmc-store-password"]
+RUN apk add --no-cache git
+RUN go get -v github.com/m-lab/epoxy-extensions/bmc-store-password
+ENTRYPOINT ["/go/bin/bmc-store-password"]

--- a/bmc-store-password/Dockerfile
+++ b/bmc-store-password/Dockerfile
@@ -1,4 +1,10 @@
-FROM golang:1.14-alpine3.12
+FROM golang:1.14-alpine3.12 as extension-build
+RUN apk add --no-cache git
 ADD . /go/src/github.com/m-lab/epoxy-extensions/bmc-store-password
-RUN go get -v github.com/m-lab/epoxy-extensions/bmc-store-password
-ENTRYPOINT ["/go/bin/bmc-store-password"]
+RUN cd /go/src/github.com/m-lab/epoxy-extensions/bmc-store-password && ./build.sh
+
+# Now copy the built image into the minimal base image
+FROM alpine:3.12
+COPY --from=ext-build /go/bin/bmc-store-password /
+WORKDIR /
+ENTRYPOINT ["/bmc-store-password"]

--- a/bmc-store-password/main.go
+++ b/bmc-store-password/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 k8s-support Authors
+// Copyright 2020 M-Lab Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,12 +13,12 @@
 // limitations under the License.
 //////////////////////////////////////////////////////////////////////////////
 
-// bmc-password implements the epoxy extension API and provides a way for
+// bmc-store-password implements the epoxy extension API and provides a way for
 // machines booting with epoxy to store the configured BMC password to GCD.
 //
 // To deploy the bmc-password, the ePoxy server must have an extension
 // registered that maps an operation name to this server, e.g.:
-//     "store-bmc-password" -> "http://localhost:8800/store-bmc-password"
+//     "bmc-store-password" -> "http://localhost:8800/bmc-store-password"
 package main
 
 import (

--- a/bmc-store-password/main.go
+++ b/bmc-store-password/main.go
@@ -86,7 +86,7 @@ func (p *bmcPassword) Store(hostname string, password string) error {
 
 	bmcAddr, err := net.LookupHost(bmcHostname)
 	if err != nil {
-		return fmt.Errorf("Could not resolve BMC hostanme: %s", bmcHostname)
+		return fmt.Errorf("Could not resolve BMC hostname: %s", bmcHostname)
 	}
 
 	c := &creds.Credentials{

--- a/bmc-store-password/main.go
+++ b/bmc-store-password/main.go
@@ -1,0 +1,183 @@
+// Copyright 2016 k8s-support Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// bmc-password implements the epoxy extension API and provides a way for
+// machines booting with epoxy to store the configured BMC password to GCD.
+//
+// To deploy the bmc-password, the ePoxy server must have an extension
+// registered that maps an operation name to this server, e.g.:
+//     "store-bmc-password" -> "http://localhost:8800/store-bmc-password"
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/m-lab/epoxy/extension"
+	"github.com/m-lab/go/host"
+	"github.com/m-lab/reboot-service/creds"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	gcdNamespace = "reboot-api"
+)
+
+var (
+	credsNewProvider = creds.NewProvider
+	fListenAddress   = flag.String("listen-address", ":8801", "Address on which to listen for requests")
+	localPassword    password
+	// requestDuration provides a histogram of processing times. The buckets should
+	// use periods that are intuitive for people.
+	//
+	// Provides metrics:
+	//   bmc_password_request_duration_seconds{code="...", le="..."}
+	//   ...
+	//   bmc_password_request_duration_seconds{code="..."}
+	//   bmc_password_request_duration_seconds{code="..."}
+	// Usage example:
+	requestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "bmc_password_request_duration_seconds",
+			Help: "Request status codes and execution times.",
+			Buckets: []float64{
+				0.001, 0.01, 0.1, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, math.Inf(+1),
+			},
+		},
+		[]string{"method", "code"},
+	)
+)
+
+// passwordStorer defines the interface for storing BMC passwords.
+type password interface {
+	Store(target string, password string) error
+}
+
+type bmcPassword struct{}
+
+// Token generates a new k8s token.
+func (p *bmcPassword) Store(hostname string, password string) error {
+	parts, err := host.Parse(hostname)
+	if err != nil {
+		return fmt.Errorf("Could not parse hostname: %s", hostname)
+	}
+
+	bmcHostname := strings.Replace(hostname, parts.Machine, parts.Machine+"d", 1)
+
+	bmcAddr, err := net.LookupHost(bmcHostname)
+	if err != nil {
+		return fmt.Errorf("Could not resolve BMC hostanme: %s", bmcHostname)
+	}
+
+	c := &creds.Credentials{
+		Address:  bmcAddr[0],
+		Hostname: bmcHostname,
+		Model:    "DRAC",
+		Username: "admin",
+		Password: password,
+	}
+
+	provider, err := credsNewProvider(&creds.DatastoreConnector{}, parts.Project, gcdNamespace)
+	if err != nil {
+		return fmt.Errorf("Could not connect to Google Cloud Datastore: %v", err)
+	}
+
+	err = provider.AddCredentials(context.Background(), bmcHostname, c)
+	if err != nil {
+		return fmt.Errorf("Error while adding credentials to GCD: %v", err)
+	}
+
+	return nil
+}
+
+// passwordHandler is an http.HandlerFunc for responding to an epoxy extension
+// Request.
+func passwordHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: verify this is from a trusted source (admin or epoxy source)
+	// else return HTTP 401 (Unauthorized) and fire an alert (since this should never happen)
+
+	var reqPassword []string
+
+	// Require requests to be POSTs.
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		// Write no response.
+		return
+	}
+
+	// Extract the password from the query.
+	reqPassword, ok := r.URL.Query()["p"]
+	if !ok || len(reqPassword[0]) < 1 {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Println("Query parameter 'p' missing in request.")
+		// Write no response.
+		return
+	}
+
+	// Decode the extension request.
+	ext := &extension.Request{}
+	err := ext.Decode(r.Body)
+	if err != nil || ext.V1 == nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusBadRequest)
+		// Write no response.
+		return
+	}
+	if time.Now().UTC().Sub(ext.V1.LastBoot) > 120*time.Minute {
+		// According to ePoxy the machine booted over 2 hours ago,
+		// which is longer than we're willing to support.
+		w.WriteHeader(http.StatusRequestTimeout)
+		// Write no response.
+		return
+	}
+
+	log.Println("Request: ", ext.Encode())
+
+	err = localPassword.Store(ext.V1.Hostname, reqPassword[0])
+	if err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		// Write no response.
+		return
+	}
+
+	// Write response to caller.
+	w.WriteHeader(http.StatusOK)
+	return
+}
+
+func init() {
+	prometheus.MustRegister(requestDuration)
+}
+
+func main() {
+	flag.Parse()
+
+	localPassword = &bmcPassword{}
+
+	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/v1/bmc-store-password",
+		promhttp.InstrumentHandlerDuration(
+			requestDuration, http.HandlerFunc(passwordHandler)))
+	log.Fatal(http.ListenAndServe(*fListenAddress, nil))
+}

--- a/bmc-store-password/main_test.go
+++ b/bmc-store-password/main_test.go
@@ -1,0 +1,141 @@
+// Copyright 2016 k8s-support Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/m-lab/epoxy/extension"
+)
+
+type fakeTokenGenerator struct {
+	token string
+}
+
+func (g *fakeTokenGenerator) Token(target string) ([]byte, error) {
+	if g.token == "" {
+		return nil, fmt.Errorf("Failing to generate token")
+	}
+	return []byte(g.token), nil
+}
+
+func Test_allocateTokenHandler(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		body   string
+		v1     *extension.V1
+		status int
+		token  string
+	}{
+		{
+			name:   "success",
+			method: "POST",
+			v1: &extension.V1{
+				Hostname:    "mlab1-foo01.mlab-oti.measurement-lab.org",
+				IPv4Address: "192.168.1.1",
+				LastBoot:    time.Now().UTC().Add(-5 * time.Minute),
+			},
+			status: http.StatusOK,
+			token:  "012345.abcdefghijklmnop",
+		},
+		{
+			name:   "failure-bad-method",
+			method: "GET",
+			status: http.StatusMethodNotAllowed,
+		},
+		{
+			name:   "failure-bad-requested",
+			method: "POST",
+			v1:     nil,
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "failure-last-boot-too-old",
+			method: "POST",
+			v1: &extension.V1{
+				Hostname:    "mlab1-foo01.mlab-oti.measurement-lab.org",
+				IPv4Address: "192.168.1.1",
+				LastBoot:    time.Now().UTC().Add(-125 * time.Minute),
+			},
+			status: http.StatusRequestTimeout,
+		},
+		{
+			name:   "failure-failure-to-generate-token",
+			method: "POST",
+			v1: &extension.V1{
+				Hostname:    "mlab1-foo01.mlab-oti.measurement-lab.org",
+				IPv4Address: "192.168.1.1",
+				LastBoot:    time.Now().UTC().Add(-5 * time.Minute),
+			},
+			status: http.StatusInternalServerError,
+			token:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localGenerator = &fakeTokenGenerator{token: tt.token}
+			ext := extension.Request{V1: tt.v1}
+			req := httptest.NewRequest(
+				tt.method, "/allocate_k8s_token", strings.NewReader(ext.Encode()))
+			rec := httptest.NewRecorder()
+
+			allocateTokenHandler(rec, req)
+
+			if tt.status != rec.Code {
+				t.Errorf("allocateTokenHandler() bad status code: got %d; want %d",
+					rec.Code, tt.status)
+			}
+			if rec.Body.String() != tt.token {
+				t.Errorf("allocateTokenHandler() bad token returned: got %q; want %q",
+					rec.Body.String(), tt.token)
+			}
+		})
+	}
+}
+
+func Test_k8sTokenGenerator_Token(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		response string
+	}{
+		{
+			name:     "success",
+			command:  "/bin/echo",
+			response: "token create --ttl 5m --description Allow test to join the cluster\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &k8sTokenGenerator{
+				Command: tt.command,
+			}
+			got, err := g.Token("test")
+			if err != nil {
+				t.Fatalf("k8sTokenGenerator.Token() = %q, want nil", err)
+			}
+			if string(got) != tt.response {
+				t.Errorf("k8sTokenGenerator.Token() = %q, want %q", got, tt.response)
+			}
+		})
+	}
+}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,25 @@
+timeout: 1800s
+
+options:
+  env:
+  - COMMIT_SHA=$COMMIT_SHA
+  - GIT_ORIGIN_URL=https://github.com/m-lab/epoxy-extensions.git
+  - WORKSPACE_LINK=/go/src/github.com/m-lab/epoxy-extensions
+
+steps:
+
+# Run unit tests for environment.
+- name: gcr.io/$PROJECT_ID/golang-cbif
+  args:
+  - go version
+  - go get -v -t ./...
+  - go vet ./...
+  - go test ./... -race
+  - go test -v ./...
+
+# Be sure building the bmc-store-password Docker image works.
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build', '--tag=gcr.io/$PROJECT_ID/disco', './bmc-store-password/'
+  ]
+


### PR DESCRIPTION
This PR is part of resolving https://github.com/m-lab/epoxy/issues/94

Currently, setting up Google Cloud Datastore entities for BMCs is a manual process. Additionally, it is still necessary to run `configure_drac.py` for every new machine, another manual step. This PR represents the first step in automating this process by implementing a small ePoxy extension that will receive a BMC password from the stage1 boot process of a node, and then create a new GCD entity for that node (or update an existing entity). There will still be quite a few other steps to actually get this working, but this is a first step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-extensions/1)
<!-- Reviewable:end -->
