### PR TITLE
Fixes http.HandleFunc to handle the right query path.

### DIFF
--- a/bmc-store-password/main.go
+++ b/bmc-store-password/main.go
@@ -177,7 +177,7 @@ func main() {
 	localPassword = &bmcPassword{}
 
 	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/v1/bmc-store-password",
+	http.HandleFunc("/v1/bmc_store_password",
 		promhttp.InstrumentHandlerDuration(
 			requestDuration, http.HandlerFunc(passwordHandler)))
 	log.Printf("Listening on interface: %s", *fListenAddress)


### PR DESCRIPTION
ePoxy is configured to query the bmc-store-password extension at query path `/v1/bmc_store_password`. This PR just bring the http request handler function to listen for this same query path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-extensions/3)
<!-- Reviewable:end -->
